### PR TITLE
Skip binary files before reading them

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -11,7 +11,7 @@ const writeFileAsync = util.promisify(fs.writeFile);
 // linkSync files does't work with concurrency
 const TRANSFORM_CONCURRENCY = 1;
 
-async function editFiles(expresion, callback) {
+async function editTextFiles(expresion, callback) {
   const paths = await globby(expresion);
 
   return pMap(
@@ -77,4 +77,4 @@ async function syncAllLinks({ htmlGlob = 'public/**/*.html', assetFolder = 'publ
   });
 }
 
-module.exports = { editFiles, moveAllAssets, copyAllAssets, syncAllLinks };
+module.exports = { editTextFiles, moveAllAssets, copyAllAssets, syncAllLinks };

--- a/src/core.js
+++ b/src/core.js
@@ -3,6 +3,7 @@ const util = require('util');
 const pMap = require('p-map');
 const globby = require('globby');
 const klawSync = require('klaw-sync');
+const isTextPath = require('is-text-path');
 
 const readFileAsync = util.promisify(fs.readFile);
 const writeFileAsync = util.promisify(fs.writeFile);
@@ -14,7 +15,7 @@ async function editFiles(expresion, callback) {
   const paths = await globby(expresion);
 
   return pMap(
-    paths,
+    paths.filter(isTextPath),
     async (path) => {
       let contents = await readFileAsync(path, 'utf-8');
       const result = await callback({ path, contents });

--- a/src/relative-paths.js
+++ b/src/relative-paths.js
@@ -1,4 +1,4 @@
-const { editFiles, copyAllAssets } = require('./core');
+const { editTextFiles, copyAllAssets } = require('./core');
 
 class RelativizeContent {
   constructor({ assetPrefix, verbose = false }) {
@@ -36,16 +36,16 @@ class RelativizeContent {
 async function relativizeFiles({ assetPrefix, assetFolder = 'public/assets', verbose }) {
   const relativize = new RelativizeContent({ assetPrefix, assetFolder, verbose });
 
-  await editFiles(['public/**/*.html'], ({ path, contents }) => {
+  await editTextFiles(['public/**/*.html'], ({ path, contents }) => {
     copyAllAssets(path, { assetFolder });
     return relativize.inHtmlFiles({ path, contents });
   });
 
-  await editFiles(['public/**/*.{js,js.map}'], ({ path, contents }) => {
+  await editTextFiles(['public/**/*.{js,js.map}'], ({ path, contents }) => {
     return relativize.inJsFiles({ contents, path });
   });
 
-  await editFiles(['public/**/*', '!public/**/*.html', '!public/**/*.{js,js.map}'], ({ path, contents }) => {
+  await editTextFiles(['public/**/*', '!public/**/*.html', '!public/**/*.{js,js.map}'], ({ path, contents }) => {
     return relativize.inMiscAssetFiles({ contents, path });
   });
 

--- a/src/relative-paths.js
+++ b/src/relative-paths.js
@@ -1,4 +1,3 @@
-const isTextPath = require('is-text-path');
 const { editFiles, copyAllAssets } = require('./core');
 
 class RelativizeContent {
@@ -27,8 +26,6 @@ class RelativizeContent {
   }
 
   inMiscAssetFiles({ path, contents }) {
-    // Skip if is a binary file
-    if (!isTextPath(path)) return contents;
     if (!contents.includes(this.assetPrefix)) return contents;
     contents = contents.replace(new RegExp(`(/${this.assetPrefix}|${this.assetPrefix})`, 'g'), `./assets`);
     this.verbose && console.log('[relative-paths][MISC]', path, `${this.assetPrefix} => ./assets`);


### PR DESCRIPTION
This PR filters out binary paths early on, as part of a repurposed utility function `editFiles` renamed to `editTextFiles`.

This prevents asset corruption which occurs when a binary file is read with `utf-8` encoding before being written back by avoiding unnecessary read-write cycles.